### PR TITLE
Refactor: use react-modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "@tanstack/react-query": "^4.26.1",
     "@tanstack/react-query-devtools": "^4.26.1",
     "@types/axios": "^0.14.0",
+    "@types/react-modal": "^3.13.1",
     "@types/react-query": "^1.2.9",
     "@types/react-router-dom": "^5.3.3",
     "axios": "^1.3.4",
     "react-beautiful-dnd": "^13.1.1",
+    "react-modal": "^3.16.1",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.8.2",
     "styled-components": "^5.3.8"

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,5 +1,5 @@
 import { MODAL_TYPE } from "@/constants";
-import useModal from "@utils/hooks/useModal";
+import useModal from "@/hooks/useModal";
 import * as S from "./style";
 
 const Card = () => {

--- a/src/components/CardDetail/index.tsx
+++ b/src/components/CardDetail/index.tsx
@@ -1,12 +1,12 @@
 import useModal from "@utils/hooks/useModal";
 import * as S from "./style";
 
-const CardDetail = () => {
+const CardDetail = ({ title }: { title: string }) => {
   const { closeModal } = useModal();
 
   return (
     <S.Container>
-      CardDetail
+      {title}
       <S.CloseButton onClick={closeModal}>X</S.CloseButton>
     </S.Container>
   );

--- a/src/components/CardDetail/index.tsx
+++ b/src/components/CardDetail/index.tsx
@@ -1,4 +1,4 @@
-import useModal from "@utils/hooks/useModal";
+import useModal from "@/hooks/useModal";
 import * as S from "./style";
 
 const CardDetail = ({ title }: { title: string }) => {

--- a/src/components/CardEdit/index.tsx
+++ b/src/components/CardEdit/index.tsx
@@ -1,4 +1,4 @@
-const CardEdit = () => {
+const CardEdit = ({ text }: { text: string }) => {
   return <div>CardEdit</div>;
 };
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,37 +1,41 @@
-import { useRef } from "react";
+import React, { useRef, Suspense } from "react";
 import { useSelector } from "react-redux";
 import { createPortal } from "react-dom";
 import { MODAL_TYPE } from "@/constants";
-import useOutsideClick from "@utils/hooks/useClickOutside";
-import useModal from "@utils/hooks/useModal";
+import useOutsideClick from "@/hooks/useClickOutside";
+import useModal from "@/hooks/useModal";
 import { ModalState } from "@/store/slices/modal";
-import CardDetail from "@components/CardDetail";
-import CardEdit from "@components/CardEdit";
 import * as S from "./style";
 
 interface ModalComponent {
-  [key: string]: JSX.Element;
+  [key: string]: any;
 }
 
 const Modal = () => {
   const { closeModal } = useModal();
   const clickOutsideRef = useRef<HTMLDivElement>(null);
-  const { type, options, props } = useSelector(
+  const { type, props } = useSelector(
     (state: { modal: ModalState }) => state.modal
   );
   const isModalOpened = type !== MODAL_TYPE.NONE ? true : false;
   useOutsideClick(clickOutsideRef, () => closeModal());
   const modalComponent: ModalComponent = {
-    [MODAL_TYPE.CARD_EDIT]: <CardEdit />,
-    [MODAL_TYPE.CARD_DETAIL]: <CardDetail />,
+    [MODAL_TYPE.CARD_EDIT]: React.lazy(() => import("@components/CardEdit")),
+    [MODAL_TYPE.CARD_DETAIL]: React.lazy(
+      () => import("@components/CardDetail")
+    ),
   };
+
+  const CurrentComponent = modalComponent[type];
 
   return (
     <ModalPortal>
       {isModalOpened && (
         <S.DimmedBackground>
           <S.Container ref={clickOutsideRef}>
-            {modalComponent[type] && modalComponent[type]}
+            <Suspense fallback={<div>is loading...</div>}>
+              {modalComponent[type] && <CurrentComponent {...props} />}
+            </Suspense>
           </S.Container>
         </S.DimmedBackground>
       )}

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -27,17 +27,15 @@ const Modal = () => {
   const CurrentComponent = modalComponent[type];
 
   return (
-    <>
-      {isModalOpened && (
-        <S.DimmedBackground>
-          <ReactModal isOpen={isModalOpened} onRequestClose={closeModal}>
-            <Suspense fallback={<div>is loading...</div>}>
-              {modalComponent[type] && <CurrentComponent {...props} />}
-            </Suspense>
-          </ReactModal>
-        </S.DimmedBackground>
-      )}
-    </>
+    <ReactModal
+      isOpen={isModalOpened}
+      onRequestClose={closeModal}
+      style={S.ModalStyle}
+    >
+      <Suspense fallback={<div>is loading...</div>}>
+        {modalComponent[type] && <CurrentComponent {...props} />}
+      </Suspense>
+    </ReactModal>
   );
 };
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,8 +1,7 @@
-import React, { useRef, Suspense } from "react";
+import React, { Suspense } from "react";
+import ReactModal from "react-modal";
 import { useSelector } from "react-redux";
-import { createPortal } from "react-dom";
 import { MODAL_TYPE } from "@/constants";
-import useOutsideClick from "@/hooks/useClickOutside";
 import useModal from "@/hooks/useModal";
 import { ModalState } from "@/store/slices/modal";
 import * as S from "./style";
@@ -13,12 +12,11 @@ interface ModalComponent {
 
 const Modal = () => {
   const { closeModal } = useModal();
-  const clickOutsideRef = useRef<HTMLDivElement>(null);
   const { type, props } = useSelector(
     (state: { modal: ModalState }) => state.modal
   );
+
   const isModalOpened = type !== MODAL_TYPE.NONE ? true : false;
-  useOutsideClick(clickOutsideRef, () => closeModal());
   const modalComponent: ModalComponent = {
     [MODAL_TYPE.CARD_EDIT]: React.lazy(() => import("@components/CardEdit")),
     [MODAL_TYPE.CARD_DETAIL]: React.lazy(
@@ -29,23 +27,18 @@ const Modal = () => {
   const CurrentComponent = modalComponent[type];
 
   return (
-    <ModalPortal>
+    <>
       {isModalOpened && (
         <S.DimmedBackground>
-          <S.Container ref={clickOutsideRef}>
+          <ReactModal isOpen={isModalOpened} onRequestClose={closeModal}>
             <Suspense fallback={<div>is loading...</div>}>
               {modalComponent[type] && <CurrentComponent {...props} />}
             </Suspense>
-          </S.Container>
+          </ReactModal>
         </S.DimmedBackground>
       )}
-    </ModalPortal>
+    </>
   );
 };
 
 export default Modal;
-
-const ModalPortal = ({ children }: { children: JSX.Element | boolean }) => {
-  const el = document.getElementById("modal") as HTMLElement;
-  return createPortal(children, el);
-};

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -7,8 +7,11 @@ import { ModalState } from "@/store/slices/modal";
 import * as S from "./style";
 
 interface ModalComponent {
-  [key: string]: any;
+  [x: string]: CardEdit | CardDetail;
 }
+type Props<T> = React.LazyExoticComponent<(props: T) => JSX.Element>;
+type CardEdit = Props<{ text: string }>;
+type CardDetail = Props<{ title: string }>;
 
 const Modal = () => {
   const { closeModal } = useModal();
@@ -23,6 +26,11 @@ const Modal = () => {
       () => import("@components/CardDetail")
     ),
   };
+
+  interface Modals {
+    [MODAL_TYPE.CARD_EDIT]: CardEdit;
+    [MODAL_TYPE.CARD_DETAIL]: CardDetail;
+  }
 
   const CurrentComponent = modalComponent[type];
 

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -6,12 +6,9 @@ import useModal from "@/hooks/useModal";
 import { ModalState } from "@/store/slices/modal";
 import * as S from "./style";
 
-interface ModalComponent {
-  [x: string]: CardEdit | CardDetail;
+interface ModalComponent<T = any> {
+  [x: string]: React.LazyExoticComponent<(props: T) => JSX.Element>;
 }
-type Props<T> = React.LazyExoticComponent<(props: T) => JSX.Element>;
-type CardEdit = Props<{ text: string }>;
-type CardDetail = Props<{ title: string }>;
 
 const Modal = () => {
   const { closeModal } = useModal();
@@ -26,11 +23,6 @@ const Modal = () => {
       () => import("@components/CardDetail")
     ),
   };
-
-  interface Modals {
-    [MODAL_TYPE.CARD_EDIT]: CardEdit;
-    [MODAL_TYPE.CARD_DETAIL]: CardDetail;
-  }
 
   const CurrentComponent = modalComponent[type];
 

--- a/src/components/Modal/style.ts
+++ b/src/components/Modal/style.ts
@@ -1,19 +1,13 @@
-import styled from "styled-components";
+import { theme } from "@/styles/theme";
 
-export const DimmedBackground = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background-color: ${({ theme }) => theme.color.dimmedBackground};
-`;
-
-export const Container = styled.div`
-  // temporal style
-  position: fixed;
-  width: 300px;
-  height: 300px;
-  background-color: white;
-  transform: translate(25vw, 25vh);
-`;
+export const ModalStyle = {
+  overlay: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: `${theme.color.dimmedBackground}`,
+  },
+  content: {
+    inset: "unset",
+  },
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,6 +1,4 @@
-import { DefaultTheme } from "styled-components"; // ✨ 1
-
-export const theme: DefaultTheme = {
+export const theme = {
   color: {
     dimmedBackground: "#000000a3",
     backgroundGray: "#F3F5F7", // modal background

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export const utils = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3553,23 +3553,23 @@ __metadata:
   linkType: hard
 
 "@tanstack/react-query-devtools@npm:^4.26.1":
-  version: 4.27.0
-  resolution: "@tanstack/react-query-devtools@npm:4.27.0"
+  version: 4.28.0
+  resolution: "@tanstack/react-query-devtools@npm:4.28.0"
   dependencies:
     "@tanstack/match-sorter-utils": ^8.7.0
     superjson: ^1.10.0
     use-sync-external-store: ^1.2.0
   peerDependencies:
-    "@tanstack/react-query": 4.27.0
+    "@tanstack/react-query": 4.28.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 0477a08285d6955c2c4cf6567439a907ec390510968b3e8beb3a89fc9a0ac10bec7e38cd0d906184906500c5220121e874adf924f84045a46cb9f564c03b9134
+  checksum: 76d39c4f5d2a884e6b7af9dee39f1f2427da515cd6bd3ddc99d1d97ec5fa01db5c134ac0d0fab57cdc860a736a3aa0443cc35295e302e9ff119b023663d073a6
   languageName: node
   linkType: hard
 
 "@tanstack/react-query@npm:^4.26.1":
-  version: 4.27.0
-  resolution: "@tanstack/react-query@npm:4.27.0"
+  version: 4.28.0
+  resolution: "@tanstack/react-query@npm:4.28.0"
   dependencies:
     "@tanstack/query-core": 4.27.0
     use-sync-external-store: ^1.2.0
@@ -3582,7 +3582,7 @@ __metadata:
       optional: true
     react-native:
       optional: true
-  checksum: 15cebe9ccb8df737548763223438ce0c28808e3a9f2434307d2ac966a6bb8da01f172019a5490966503797ccdf2482d1e488f5fe52de5da86dbdae20ef772e8c
+  checksum: 7baa70d22b55cfa22f8a1d92ba9f8379c5436ee81fce3f0e7df4a8c29bb26bfef4a83759cf10f752b40ae2940099fcce88ce91a773240f4999ae91136980c6e3
   languageName: node
   linkType: hard
 
@@ -3663,12 +3663,12 @@ __metadata:
   linkType: hard
 
 "@types/eslint@npm:*":
-  version: 8.21.2
-  resolution: "@types/eslint@npm:8.21.2"
+  version: 8.21.3
+  resolution: "@types/eslint@npm:8.21.3"
   dependencies:
     "@types/estree": "*"
     "@types/json-schema": "*"
-  checksum: a48864c837137ee5b3f4f934a5468dc00456c998a2479f8f7ba1c2c34e1fc08414d9f49157f90814a9e843b1dd2cd824b4660cba9425e23d109250ec7ae0a259
+  checksum: 80e0b5ca9ffb77bff19d01df08b93a99a6b44cad4c40e6450733ead6f1bc44b5514e7d28c3b0ad6304aeb01d690ee7ca89250729a9373551b7e587c6dbb41d7f
   languageName: node
   linkType: hard
 
@@ -3802,11 +3802,11 @@ __metadata:
   linkType: hard
 
 "@types/mdast@npm:^3.0.0":
-  version: 3.0.10
-  resolution: "@types/mdast@npm:3.0.10"
+  version: 3.0.11
+  resolution: "@types/mdast@npm:3.0.11"
   dependencies:
     "@types/unist": "*"
-  checksum: 3f587bfc0a9a2403ecadc220e61031b01734fedaf82e27eb4d5ba039c0eb54db8c85681ccc070ab4df3f7ec711b736a82b990e69caa14c74bf7ac0ccf2ac7313
+  checksum: 3b04cf465535553b47a1811c247668bd6cfeb54d99a2c9dbb82ccd0f5145d271d10c3169f929701d8cd55fd569f0d2e459a50845813ba3261f1fb0395a288cea
   languageName: node
   linkType: hard
 
@@ -3835,23 +3835,23 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*, @types/node@npm:^18.15.0":
-  version: 18.15.3
-  resolution: "@types/node@npm:18.15.3"
-  checksum: 31b1d92475a82c30de29aa6c0771b18a276552d191283b4423ba2d61b3f01159bf0d02576c0b7cc834b043997893800db6bb47f246083ed85aa45e79c80875d7
+  version: 18.15.5
+  resolution: "@types/node@npm:18.15.5"
+  checksum: 5fbf3453bd5ce1402bb2964e55d928fc8a8a7de5451b1b0fe66587fecb8a3eb86854ca9cefa5076a5971e2cff00e1773ceeb5d872a54f6c6ddfbbc1064b4e91a
   languageName: node
   linkType: hard
 
 "@types/node@npm:^14.0.10 || ^16.0.0, @types/node@npm:^14.14.20 || ^16.0.0":
-  version: 16.18.16
-  resolution: "@types/node@npm:16.18.16"
-  checksum: 69c422450f046fbdf1904c4fdb9fbc80fda379768f6e5402ac1434fb5955b7b3d0082f02fb9bcd4979f57649ecd9a934277492d757c6ea88d080ba101c1ced48
+  version: 16.18.18
+  resolution: "@types/node@npm:16.18.18"
+  checksum: 021936e4fcd5cb038cd5d2d26328c7c0bf501d15793e48a12501129cf8770cbbe9a6936fcb64eeb10a102ff273c2606b75c1635a5834abd786014c98c112aaee
   languageName: node
   linkType: hard
 
 "@types/node@npm:^14.14.31":
-  version: 14.18.38
-  resolution: "@types/node@npm:14.18.38"
-  checksum: 4f580c5e0f124f44fa6f5d9923bf8fd98f644caabee6171c2dac48160062a91de99f2edd5db5ec59e93fe61f85dd4111df78c9d4f341f3aafca719929362303f
+  version: 14.18.40
+  resolution: "@types/node@npm:14.18.40"
+  checksum: 99029290936a6be679dfe5f82687f2f164aedd35f436837577d12cb183a6c4021bd9f9a3093bef07a69b35af3de01b28a7625793f60677511418ace544c4deda
   languageName: node
   linkType: hard
 
@@ -5866,9 +5866,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.30001109, caniuse-lite@npm:^1.0.30001449":
-  version: 1.0.30001467
-  resolution: "caniuse-lite@npm:1.0.30001467"
-  checksum: c7df36ddb8050fb366a4bedd278f4b639c1dde94b6ba62bacf960f26d488395632a0630b7932ebc52d3d04b57940d12dcb4a7d3bb744ff64c249b61fb3e0c238
+  version: 1.0.30001468
+  resolution: "caniuse-lite@npm:1.0.30001468"
+  checksum: 39f23ce5af90fee37004bee334cd809a20f8aa46ef08244f75e33d2e32b53cfebee205018769a2712937fa05ea5a1c0249175771ffee561acd1e8e05c54f9a67
   languageName: node
   linkType: hard
 
@@ -7209,9 +7209,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.4.284":
-  version: 1.4.333
-  resolution: "electron-to-chromium@npm:1.4.333"
-  checksum: 028f6618f18addf619a5a5eeca01c07fa3052ef4912b98e03e19c419eb92b6ed69bdb9c2bb499761186fdc60f9e955fa34a4b96e50b03d98a4a0bcb01aef8afd
+  version: 1.4.334
+  resolution: "electron-to-chromium@npm:1.4.334"
+  checksum: 8092fd18e30c68f68b197f7c151c149806fe307210d86a74c0544e05540c49b3de17e48def6c04af7886cefb927c45910cc18fddc475c0ed17ff0a1ddbc94268
   languageName: node
   linkType: hard
 
@@ -11448,8 +11448,8 @@ __metadata:
   linkType: hard
 
 "msw@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "msw@npm:1.1.0"
+  version: 1.1.1
+  resolution: "msw@npm:1.1.1"
   dependencies:
     "@mswjs/cookies": ^0.2.2
     "@mswjs/interceptors": ^0.17.5
@@ -11471,13 +11471,13 @@ __metadata:
     type-fest: ^2.19.0
     yargs: ^17.3.1
   peerDependencies:
-    typescript: ">= 4.4.x <= 4.9.x"
+    typescript: ">= 4.4.x <= 5.0.x"
   peerDependenciesMeta:
     typescript:
       optional: true
   bin:
     msw: cli/index.js
-  checksum: e555547defbc3f07532bdadcbf9f4e3a32b92156d3869e85c9038ecaac220cfc93901727da097b7f9d3ecf9cbbc5a9178c0ecdd3999a9201db4c85c99b92c361
+  checksum: d99c13911a2f3bc3b07a38ed60e0ec19883bc89e3f77a2d7609ce580eb4f50883e2b15ef140927fc0424e661ef1c455eea8fcd614202f2eaef66f53b794356f7
   languageName: node
   linkType: hard
 
@@ -13721,8 +13721,8 @@ __metadata:
   linkType: hard
 
 "rollup@npm:^3.18.0":
-  version: 3.19.1
-  resolution: "rollup@npm:3.19.1"
+  version: 3.20.0
+  resolution: "rollup@npm:3.20.0"
   dependencies:
     fsevents: ~2.3.2
   dependenciesMeta:
@@ -13730,7 +13730,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: f78198c6de224b26650c70b16db156762d1fcceeb375d34fb2c76fc5b23a78f712c3c881d3248e6f277a511589e20d50c247bcf5c7920f1ddc0a43cadf9f0140
+  checksum: ebf75f48eb81234f8233b4ed145b00841cefba26802d4f069f161247ffba085ca5bb165cc3cd662d9c36cfc135a67660dfff9088d3da2d2c6a70addc15f3233a
   languageName: node
   linkType: hard
 
@@ -15824,8 +15824,8 @@ __metadata:
   linkType: hard
 
 "vite@npm:^4.1.4":
-  version: 4.2.0
-  resolution: "vite@npm:4.2.0"
+  version: 4.2.1
+  resolution: "vite@npm:4.2.1"
   dependencies:
     esbuild: ^0.17.5
     fsevents: ~2.3.2
@@ -15857,7 +15857,11 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
+<<<<<<< HEAD
   checksum: 1088cdc0c89ab835aab07a0a114397b749e8dfb20f4b94241ba179d9c371b72d31e13782b22893860c3d65da596e43b24fce5e023f79cfde427f42549f2e1844
+=======
+  checksum: 70eb162ffc299017a3c310e3adc95e9661def6b17aafd1f8e5e02e516766060435590dbe3df1e4e95acc3583c728a76e91f07c546221d1e701f1b2b021293f45
+>>>>>>> c315ec3 (Fix: modalComponent props type setting any type as default)
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3904,6 +3904,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-modal@npm:^3.13.1":
+  version: 3.13.1
+  resolution: "@types/react-modal@npm:3.13.1"
+  dependencies:
+    "@types/react": "*"
+  checksum: b0ad403e0051a2882e9086c6006cc342901b1c90caf760893b31717a5cbc04f86cc1ea7b5ce12a2c8350c9c09e9b344de3783404e70b7c7ea6a037d0ffd70e99
+  languageName: node
+  linkType: hard
+
 "@types/react-query@npm:^1.2.9":
   version: 1.2.9
   resolution: "@types/react-query@npm:1.2.9"
@@ -7875,6 +7884,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"exenv@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "exenv@npm:1.2.2"
+  checksum: a894f3b60ab8419e0b6eec99c690a009c8276b4c90655ccaf7d28faba2de3a6b93b3d92210f9dc5efd36058d44f04098f6bbccef99859151104bfd49939904dc
+  languageName: node
+  linkType: hard
+
 "expand-brackets@npm:^2.1.4":
   version: 2.1.4
   resolution: "expand-brackets@npm:2.1.4"
@@ -10773,7 +10789,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -13093,10 +13109,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-lifecycles-compat@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "react-lifecycles-compat@npm:3.0.4"
+  checksum: a904b0fc0a8eeb15a148c9feb7bc17cec7ef96e71188280061fc340043fd6d8ee3ff233381f0e8f95c1cf926210b2c4a31f38182c8f35ac55057e453d6df204f
+  languageName: node
+  linkType: hard
+
 "react-merge-refs@npm:^1.0.0":
   version: 1.1.0
   resolution: "react-merge-refs@npm:1.1.0"
   checksum: 90884352999002d868ab9f1bcfe3222fb0f2178ed629f1da7e98e5a9b02a2c96b4aa72800db92aabd69d2483211b4be57a2088e89a11a0b660e7ada744d4ddf7
+  languageName: node
+  linkType: hard
+
+"react-modal@npm:^3.16.1":
+  version: 3.16.1
+  resolution: "react-modal@npm:3.16.1"
+  dependencies:
+    exenv: ^1.2.0
+    prop-types: ^15.7.2
+    react-lifecycles-compat: ^3.0.0
+    warning: ^4.0.3
+  peerDependencies:
+    react: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
+    react-dom: ^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18
+  checksum: 978936e9320fad839c039b9ee4de55d40888156cb40e093615d6fbc2ff07139d5db06f14782cb7767f780bd5fb57956778669426c535ebc0068a7a03882c7e75
   languageName: node
   linkType: hard
 
@@ -15057,6 +15095,7 @@ __metadata:
     "@tanstack/react-query-devtools": ^4.26.1
     "@types/axios": ^0.14.0
     "@types/node": ^18.15.0
+    "@types/react-modal": ^3.13.1
     "@types/react-query": ^1.2.9
     "@types/react-router-dom": ^5.3.3
     "@types/styled-components": ^5.1.26
@@ -15065,6 +15104,7 @@ __metadata:
     cypress: ^12.7.0
     msw: ^1.1.0
     react-beautiful-dnd: ^13.1.1
+    react-modal: ^3.16.1
     react-redux: ^8.0.5
     react-router-dom: ^6.8.2
     styled-components: ^5.3.8
@@ -15834,6 +15874,15 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
+  languageName: node
+  linkType: hard
+
+"warning@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "warning@npm:4.0.3"
+  dependencies:
+    loose-envify: ^1.0.0
+  checksum: 4f2cb6a9575e4faf71ddad9ad1ae7a00d0a75d24521c193fa464f30e6b04027bd97aa5d9546b0e13d3a150ab402eda216d59c1d0f2d6ca60124d96cd40dfa35c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

- react-modal 사용해 모달 관리하도록 추가

<img width="579" alt="스크린샷 2023-03-19 오후 3 38 21" src="https://user-images.githubusercontent.com/67543454/226158577-8eba9af7-1cc4-4a83-a320-e21e4d80ae49.png">

### Question
- ModalComponent interface의 value type이 지금은 any인데,  어떻게 고쳐야 할지 잘 모르겠습니다.
- modalComponent 객체에 key로 접근해 팝업 내 표시할 컴포넌트를 정해 렌더링할 때, 어떤 props형태를 컴포넌트로 넘겨주게 될지 타입을 알려줄 수 없는 문제가 있습니다.


```tsx
  const modalComponent = {
    [MODAL_TYPE.CARD_EDIT]: React.lazy(() => import("@components/CardEdit")),
    [MODAL_TYPE.CARD_DETAIL]: React.lazy(
      () => import("@components/CardDetail") // CardDetail 컴포넌트에 전달할 props 타입 지정 필요
    ),
  };

    //...
    <ReactModal
      isOpen={isModalOpened}
      onRequestClose={closeModal}
      style={S.ModalStyle}
    >
      <Suspense fallback={<div>is loading...</div>}>
        {modalComponent[type] && <CurrentComponent {...props} />}
          //Property 'title' is missing in type '{}' but required in type '{ title: string; }'.
      </Suspense>
    </ReactModal>
```

```tsx
//각 컴포넌트 별 전달받는 props
const CardDetail = ({ title }: { title: string }) => {
  //...
const CardEdit = ({ text }: { text: string }) => {
  //...
```

- modalComponent의 value값의 타입은 아래와 같아서, `React.LazyExoticComponent<(props) => JSX.Element>`에서 props에 대한 타입을 제네릭으로 지정해보았습니다.
```tsx
React.LazyExoticComponent<({ title }: {
    title: string;
}) => JSX.Element>
```

```tsx
interface ModalComponent {
  [x: string]: CardEdit | CardDetail;
}
type Props<T> = React.LazyExoticComponent<(props: T) => JSX.Element>;
type CardEdit = Props<{ text: string }>;
type CardDetail = Props<{ title: string }>;

//...

      <Suspense fallback={<div>is loading...</div>}>
        {modalComponent[type] && <CurrentComponent {...props} />}
          //Property 'text' is missing in type '{}' but required in type '{ text: string; }'.
      </Suspense>
```
- 하지만 여전히 의도한대로 컴포넌트 별로 사용하는 props를 미리 알려주지 못한 것 같은데, 제가 어떤 부분을 놓쳤을까요?
- 혹은 이런 식으로 Modal컴포넌트에서 각 렌더링할 컴포넌트를 선언하고 redux로 modal type에 따라 표시하지 않고 다른 방식을 사용하는게 더 좋을까요?
