### PR TITLE
Add: header option in api request

### DIFF
--- a/src/interfaces/httpRequest.ts
+++ b/src/interfaces/httpRequest.ts
@@ -1,32 +1,32 @@
-export interface RequestParams<TQueryParams = Params, TParams = {}> {
+export interface RequestParams<TParams = data, TData = {}> {
   path: string;
   method?: RequestMethod;
+  data?: TData;
   params?: TParams;
-  queryParams?: TQueryParams;
   isMock?: boolean;
 }
 
-export type Params = Record<string, string>;
+export type data = Record<string, string>;
 type RequestMethod = "get" | "post" | "put" | "delete";
 
-export interface RequestOptions<TParams> {
-  onSuccess?: (data: TParams) => void;
+export interface RequestOptions<TData> {
+  onSuccess?: (data: TData) => void;
   onError?: (error: Error) => void;
 }
 
-export interface HandleUseQueryParams<TQueryParams = Params, TParams = object> {
+export interface HandleUseQueryParams<TParams = data, TData = object> {
   key: string;
   path: string;
-  queryParams?: TQueryParams;
-  options?: RequestOptions<TParams>;
+  params?: TParams;
+  options?: RequestOptions<TData>;
 }
 
-export interface HandleUseMutationParams<TQueryParams = Params, TParams = object, TRes = object> {
+export interface HandleUseMutationParams<TParams = data, TData = object, TRes = object> {
   key?: string;
   path: string;
   method: RequestMethod;
-  queryParams?: TQueryParams;
   params?: TParams;
+  data?: TData;
   options?: RequestOptions<TRes>;
   res?: TRes;
 }

--- a/src/interfaces/httpRequest.ts
+++ b/src/interfaces/httpRequest.ts
@@ -1,9 +1,10 @@
-export interface RequestParams<TQueryParams = Params, TParams = {}> {
+export interface RequestParams<TQueryParams = Params, TParams = {}, TConfig = {}> {
   path: string;
   method?: RequestMethod;
   params?: TParams;
   queryParams?: TQueryParams;
   isMock?: boolean;
+  config?: TConfig;
 }
 
 export type Params = Record<string, string>;
@@ -21,11 +22,7 @@ export interface HandleUseQueryParams<TQueryParams = Params, TParams = object> {
   options?: RequestOptions<TParams>;
 }
 
-export interface HandleUseMutationParams<
-  TQueryParams = Params,
-  TParams = object,
-  TRes = object
-> {
+export interface HandleUseMutationParams<TQueryParams = Params, TParams = object, TRes = object> {
   key?: string;
   path: string;
   method: RequestMethod;

--- a/src/interfaces/httpRequest.ts
+++ b/src/interfaces/httpRequest.ts
@@ -1,10 +1,9 @@
-export interface RequestParams<TQueryParams = Params, TParams = {}, TConfig = {}> {
+export interface RequestParams<TQueryParams = Params, TParams = {}> {
   path: string;
   method?: RequestMethod;
   params?: TParams;
   queryParams?: TQueryParams;
   isMock?: boolean;
-  config?: TConfig;
 }
 
 export type Params = Record<string, string>;

--- a/src/interfaces/httpRequest.ts
+++ b/src/interfaces/httpRequest.ts
@@ -4,6 +4,9 @@ export interface RequestParams<TParams = data, TData = {}> {
   data?: TData;
   params?: TParams;
   isMock?: boolean;
+  config?: {
+    includeAuthorization?: boolean;
+  };
 }
 
 export type data = Record<string, string>;

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -34,9 +34,6 @@ export const useAddCardMutation = () => {
         path: "/cards",
         isMock: true,
         params,
-        config: {
-          includeAuthorization: true,
-        },
       });
     },
     {
@@ -77,9 +74,6 @@ export const useAddListMutation = () => {
         path: "/lists",
         isMock: true,
         params,
-        config: {
-          includeAuthorization: true,
-        },
       });
     },
     {

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -1,3 +1,4 @@
+import { authorizedRequest } from "./../../utils/httpRequest";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { request } from "@utils/httpRequest";
 import {
@@ -30,7 +31,7 @@ export const useAddCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (data: AddCardRequest) => {
-      return request.post<ResponseMessage>({
+      return authorizedRequest.post<ResponseMessage>({
         path: "/cards",
         isMock: true,
         data,

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -30,7 +30,14 @@ export const useAddCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: AddCardRequest) => {
-      return request.post<ResponseMessage>({ path: "/cards", isMock: true, params });
+      return request.post<ResponseMessage>({
+        path: "/cards",
+        isMock: true,
+        params,
+        config: {
+          includeAuthorization: true,
+        },
+      });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -66,7 +73,14 @@ export const useAddListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
     (params: AddListRequest) => {
-      return request.post<ResponseMessage>({ path: "/lists", isMock: true, params });
+      return request.post<ResponseMessage>({
+        path: "/lists",
+        isMock: true,
+        params,
+        config: {
+          includeAuthorization: true,
+        },
+      });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),

--- a/src/queries/cards/index.ts
+++ b/src/queries/cards/index.ts
@@ -29,11 +29,11 @@ export const useCardsQuery = () => {
 export const useAddCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    (params: AddCardRequest) => {
+    (data: AddCardRequest) => {
       return request.post<ResponseMessage>({
         path: "/cards",
         isMock: true,
-        params,
+        data,
       });
     },
     {
@@ -45,8 +45,8 @@ export const useAddCardMutation = () => {
 export const useEditCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    (params: EditCardRequest) => {
-      return request.put<ResponseMessage>({ path: "/cards", isMock: true, params });
+    (data: EditCardRequest) => {
+      return request.put<ResponseMessage>({ path: "/cards", isMock: true, data });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -57,8 +57,8 @@ export const useEditCardMutation = () => {
 export const useDeleteCardMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    (params: DeleteCardRequest) => {
-      return request.delete<ResponseMessage>({ path: "/cards", isMock: true, params });
+    (data: DeleteCardRequest) => {
+      return request.delete<ResponseMessage>({ path: "/cards", isMock: true, data });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -69,11 +69,11 @@ export const useDeleteCardMutation = () => {
 export const useAddListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    (params: AddListRequest) => {
+    (data: AddListRequest) => {
       return request.post<ResponseMessage>({
         path: "/lists",
         isMock: true,
-        params,
+        data,
       });
     },
     {
@@ -85,8 +85,8 @@ export const useAddListMutation = () => {
 export const useEditListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    (params: EditListRequest) => {
-      return request.put<ResponseMessage>({ path: "/lists", isMock: true, params });
+    (data: EditListRequest) => {
+      return request.put<ResponseMessage>({ path: "/lists", isMock: true, data });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),
@@ -101,7 +101,7 @@ export const useEditCardPositionMutation = () => {
       return request.put<ResponseMessage>({
         path: `/cards/${cardId}/move`,
         isMock: true,
-        params: { destination, source },
+        data: { destination, source },
       });
     },
     {
@@ -113,8 +113,8 @@ export const useEditCardPositionMutation = () => {
 export const useDeleteListMutation = () => {
   const queryClient = useQueryClient();
   return useMutation(
-    (params: DeleteListRequest) => {
-      return request.delete<ResponseMessage>({ path: "/lists", isMock: true, params });
+    (data: DeleteListRequest) => {
+      return request.delete<ResponseMessage>({ path: "/lists", isMock: true, data });
     },
     {
       onSuccess: () => queryClient.invalidateQueries(cardListsKeys.all),

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -18,12 +18,18 @@ instance.interceptors.request.use(
 
 const handleRequestIntercept = (config: InternalAxiosRequestConfig) => {
   const token = localStorage.getItem(STORAGE_KEY.TOKEN);
-  config.headers.Authorization = !!token ? `Bearer ${token}` : "";
+
+  if (config?.headers.includeAuthorization && !!token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  delete config.headers.includeAuthorization;
   return config;
 };
 
-const fetchRequest = <TQueryParams>({ path, method, params, data, isMock }: RequestParams<TQueryParams>) => {
+const fetchRequest = <TQueryParams>({ path, method, params, data, isMock, config }: RequestParams<TQueryParams>) => {
   return instance(`${isMock ? "" : URL.API}${path}`, {
+    headers: config,
     method,
     data: JSON.stringify(data),
     params,
@@ -47,5 +53,47 @@ export const request = {
 
   delete<TResponse>(data: RequestParams): Promise<TResponse> {
     return fetchRequest({ ...data, method: "delete" });
+  },
+};
+
+export const authorizedRequest = {
+  get<TResponse>(data: RequestParams): Promise<TResponse> {
+    return fetchRequest({
+      ...data,
+      method: "get",
+      config: {
+        includeAuthorization: true,
+      },
+    });
+  },
+
+  post<TResponse>(data: RequestParams): Promise<TResponse> {
+    return fetchRequest({
+      ...data,
+      method: "post",
+      config: {
+        includeAuthorization: true,
+      },
+    });
+  },
+
+  put<TResponse>(data: RequestParams): Promise<TResponse> {
+    return fetchRequest({
+      ...data,
+      method: "put",
+      config: {
+        includeAuthorization: true,
+      },
+    });
+  },
+
+  delete<TResponse>(data: RequestParams): Promise<TResponse> {
+    return fetchRequest({
+      ...data,
+      method: "delete",
+      config: {
+        includeAuthorization: true,
+      },
+    });
   },
 };

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -14,9 +14,7 @@ const instance = axios.create({
 instance.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem(STORAGE_KEY.TOKEN);
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+    config.headers.Authorization = !!token ? `Bearer ${token}` : "";
     return config;
   },
   (error) => Promise.reject(error),


### PR DESCRIPTION
### Description

- 앱 시작 시점에 api request의 헤더값 설정할 수 있도록 파라미터 추가



### Question
- 인증정보가 필요한 api요청에 한해서만 Authorization 값을 보내도록 하는게 좋을까요?
  - 관련 로직을 찾아보면 대부분 토큰이 있으면 모든 api 요청에 대해 토큰을 헤더에 넣어 보내는 방식을 사용하는 것 같습니다. 그래서 로컬 스토리지에 토큰이 있으면 요청에 보내도록 작성했습니다.
  - 다만 찾아보니 아래와 같은 단점이 있을 수 있을 것 같아 인증정보가 필요한 api에 대해서만 Authorization값을 보내도록 하는 게 좋을지 궁금합니다.
    - 모든 API에 대해 토큰을 보내면 인증이 필요하지 않은 API에 대해서도 불필요한 인증 과정이 발생
    - 성능 저하를 유발가능성
    - 보안 측면에서도 불필요한 토큰 노출의 위험 존재
  - 937b9e6ef7e45872a2441b13226745d5df758e76 커밋에서 선택해 보내도록 코드를 작성해봤는데, 이 부분까지 고려하는게 필요할까요?


### Todo:
- [ ] axios instance baseURL 수정
  - mock api 요청용 랩핑함수 분리해 수정 
- [ ] 토큰이 만료되어 401에러 반환될 경우: refresh 토큰으로 토큰 갱신 로직 추가
- [ ] 401 에러 axios response intercepter 사용해 error handling & axios instance관련 로직 파일 분리
